### PR TITLE
Output for parsed version is `semver` and not `version`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This includes parsing out the `major`, `minor`, `patch` and the pre release aspe
 
 ## Outputs
 
-* `version`: The parsed SemVer value
+* `semver`: The parsed SemVer value
 
 * `major`: The major part of the parsed SemVer, e.g. for version `1.2.3` it would return `1`
 


### PR DESCRIPTION
The documentation is incorrect. The actual output value is under `semver`. `version` will return an empty string.